### PR TITLE
Support for arbitrary number of days of back history

### DIFF
--- a/goxapi.py
+++ b/goxapi.py
@@ -70,7 +70,7 @@ def int2str(value_int, currency):
     """return currency integer formatted as a string"""
     if currency in "BTC LTC NMC":
         return ("%16.8f" % (value_int / 100000000.0))
-    if currency == "JPY":
+    elif currency in "JPY SEK":
         return ("%12.3f" % (value_int / 1000.0))
     else:
         return ("%12.5f" % (value_int / 100000.0))
@@ -80,7 +80,7 @@ def int2float(value_int, currency):
     """convert integer to float, determine the factor by currency name"""
     if currency in "BTC LTC NMC":
         return value_int / 100000000.0
-    if currency == "JPY":
+    elif currency in "JPY SEK":
         return value_int / 1000.0
     else:
         return value_int / 100000.0
@@ -90,7 +90,7 @@ def float2int(value_float, currency):
     """convert float value to integer, determine the factor by currency name"""
     if currency in "BTC LTC NMC":
         return int(round(value_float * 100000000))
-    if currency == "JPY":
+    elif currency in "JPY SEK":
         return int(round(value_float * 1000))
     else:
         return int(round(value_float * 100000))
@@ -1230,7 +1230,7 @@ class Gox(BaseObject):
         self.currency = self.curr_quote # deprecated, use curr_quote instead
 
         # these are needed for conversion from/to intereger, float, string
-        if self.curr_quote == "JPY":
+        if self.curr_quote in "JPY SEK":
             self.mult_quote = 1e3
             self.format_quote = "%12.3f"
         else:

--- a/goxtool.py
+++ b/goxtool.py
@@ -543,7 +543,7 @@ class WinChart(Win):
         """paint a depth chart"""
 
         # pylint: disable=C0103
-        if self.gox.curr_quote == "JPY":
+        if self.gox.curr_quote in "JPY SEK":
             BAR_LEFT_EDGE = 7
             FORMAT_STRING = "%6.0f"
         else:
@@ -635,7 +635,7 @@ class WinChart(Win):
         max_vol_tot = max(max_vol_ask, max_vol_bid)
         if not max_vol_tot:
             return
-        mult_x = float(self.width - BAR_LEFT_EDGE - 1) / max_vol_tot
+        mult_x = float(self.width - BAR_LEFT_EDGE - 2) / max_vol_tot
 
         # add the own volume to the bins
         for order in book.owns:
@@ -1273,7 +1273,7 @@ def toggle_setting(gox, alternatives, option_name, direction):
 
 def toggle_depth_group(gox, direction):
     """toggle the step width of the depth chart"""
-    if gox.curr_quote == "JPY":
+    if gox.curr_quote in "JPY SEK":
         alt = ["5", "10", "25", "50", "100", "200", "500", "1000"]
     else:
         alt = ["0.05", "0.1", "0.25", "0.5", "1", "2", "5", "10"]
@@ -1282,7 +1282,7 @@ def toggle_depth_group(gox, direction):
 
 def toggle_orderbook_group(gox, direction):
     """toggle the group width of the orderbook"""
-    if gox.curr_quote == "JPY":
+    if gox.curr_quote in "JPY SEK":
         alt = ["0", "5", "10", "25", "50", "100", "200", "500", "1000"]
     else:
         alt = ["0", "0.05", "0.1", "0.25", "0.5", "1", "2", "5", "10"]


### PR DESCRIPTION
This implements an ability to tell the client how many back days of trading history to get at startup.  In addition, this should deal with long periods of connection failure by pulling trades sequentially up until the current time.

I mainly wanted to see if you'd be interested in this type of patch, which would be useful for those who want more history in their strategies.

Additional considerations:
- Takes a while to download trades, probably should have some way of caching them (maybe cpickle).
- For RAM considerations, one might want to consider garbage collecting candles over a certain age for long-running instances, but this could be a separate patch.
